### PR TITLE
Fix: quienes-somos content does not scroll

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -6,7 +6,8 @@
     <ion-title>¿Quiénes somos?</ion-title>
   </ion-toolbar>
 </ion-header>
-<ion-content>
+
+<div class="content">
   <section class="parallax bg-1">
     <div class="caption">
       <span class="border">Proyecto SiPeCaM</span>
@@ -208,7 +209,7 @@
         <ion-col size="12" size-md="6">
           <ion-card>
             <h3>Dr. Alejandro Ponce Mendoza</h3>
-            <p>Ecología</p>
+            <p>Ecología Numérica</p>
             <ion-card-content>
               <img src="assets/equipo/Alex.jpg" ALIGN="left" />
               <p>
@@ -273,7 +274,4 @@
   </section>
 
   <section class="parallax bg-7"></section>
-
-  <!-- <section class="parallax bg-8"></section>
-  <section class="parallax bg-9"></section> -->
-</ion-content>
+</div>

--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -2,6 +2,11 @@ ion-content {
   font-size: 20px;
 }
 
+.content {
+  font-size: 20px;
+  overflow-y: scroll;
+}
+
 .slider {
   height: 100%;
 }


### PR DESCRIPTION
# Current behavior
- Issue #3 

# New behavior
- Content now is scrolling on Safari/MacOS
![image](https://github.com/CONABIO-MONITOREO/sipecam_points/assets/53924990/daf6b2c5-0506-4893-928a-5331f7b4f5c8)


# Notes
- The fix was: replaced `<ion-content>` by a `<div>` with` overflow-y` set to `scroll`.
- This is a workaround while we further inspect the issue.


