### PR TITLE
Added z1 configurations

### DIFF
--- a/src/api/tableros/general.queries.ts
+++ b/src/api/tableros/general.queries.ts
@@ -126,3 +126,22 @@ export const getCumulus = gql`
     }
   }
 `;
+
+// ------- -------
+// Queries for 'z1' server
+// ------- -------
+/**
+ * KoboCounters
+ */
+export const getKoboCounters = gql`
+  query get_kobo_counters($pagination: paginationInput!) {
+    kobo_counters(pagination: $pagination) {
+      id
+      cumulus
+      name
+      value
+      kobo_asset_uid
+      kobo_asset_name
+    }
+  }
+`;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -11,6 +11,7 @@ export const environment = {
   hmr: false,
   version: env.npm_package_version,
   serverUrl: 'https://gql.sipecamdata.conabio.gob.mx',
+  kzCountersUrl: 'https://gql.sipecamdata.conabio.gob.mx/z1',
   defaultLanguage: 'en-US',
   supportedLanguages: ['en-US'],
   mapbox: {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,6 +15,7 @@ export const environment = {
   hmr: true,
   version: env.npm_package_version + '-dev',
   serverUrl: 'https://gql.sipecamdata.conabio.gob.mx',
+  kzCountersUrl: 'https://gql.sipecamdata.conabio.gob.mx/z1',
   defaultLanguage: 'en-US',
   supportedLanguages: ['en-US'],
   mapbox: {


### PR DESCRIPTION
# This PR:
- Adds support for new Zendro instance **z1**, which provides Kobo form counters for the **Formularios** chart.

- Preview on dev environment:
  - This dev instance already use the new **z1** service.
    - https://sipecamdata.conabio.gob.mx/dev/v3/tablero

- Here is the GraphiQL UI to make queries to **z1**:
  - [GraphiQL](https://gql.sipecamdata.conabio.gob.mx/z1/graphql?query=%7B%0A%20%20kobo_counters(pagination%3A%20%7B%20limit%3A%20200%20%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20name%0A%20%20%20%20value%0A%20%20%20%20kobo_asset_uid%0A%20%20%20%20kobo_asset_name%0A%20%20%7D%0A%7D)