### PR TITLE
Fix: Category names not rendered when the page loads.

### DIFF
--- a/src/app/estadisticas/tablero-general/tablero-general.component.ts
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.ts
@@ -525,6 +525,14 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
           .reduce((previous, current) => previous + current, 0);
         dataReports.push(numReports);
       });
+
+      // We need this timeout to get the categories updated correctly on load.
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(true);
+        }, 700);
+      });
+
       this.visitasChart.xaxis = {
         labels: {
           rotate: -90,
@@ -610,7 +618,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   /**
    * Query for 'z1' Zendro server.
    */
-   async getFormularios() {
+  async getFormularios() {
     try {
       const { data } = (await this.apollo
         .use('kzCounters')
@@ -664,12 +672,20 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
         eries.push(byCumulo[cumulo][eries_name] ?? 0);
       });
 
+      // We need this timeout to get the categories updated correctly on load.
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(true);
+        }, 700);
+      });
+
       this.formulariosChart.xaxis = {
         labels: {
           rotate: -90,
         },
         categories: categories,
       };
+
       this.formulariosChart.series[0].data = camaras;
       this.formulariosChart.series[1].data = grabadoras;
       this.formulariosChart.series[2].data = mamiferos;

--- a/src/app/estadisticas/tablero-general/tablero-general.component.ts
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.ts
@@ -56,6 +56,8 @@ export type ChartOptions = {
   legend: ApexLegend;
 };
 
+const updateTimeout = 300;
+
 @Component({
   selector: 'app-tablero-general',
   templateUrl: './tablero-general.component.html',
@@ -530,7 +532,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
       await new Promise((resolve) => {
         setTimeout(() => {
           resolve(true);
-        }, 700);
+        }, updateTimeout);
       });
 
       this.visitasChart.xaxis = {
@@ -676,7 +678,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
       await new Promise((resolve) => {
         setTimeout(() => {
           resolve(true);
-        }, 700);
+        }, updateTimeout);
       });
 
       this.formulariosChart.xaxis = {


### PR DESCRIPTION
# Current behavior
- Issue #6 

# New behavior
- After page load, the category names are rendered correctly.

![image](https://github.com/CONABIO-MONITOREO/sipecam_points/assets/53924990/56bde278-d5e0-4233-b403-26bd57ec3605)

# Fix
- Added an small timeout before updating the `categories` property for the affected charts. 