### PR TITLE
Added graphs with information about deliveries

### DIFF
--- a/src/app/estadisticas/tablero-general/tablero-general.component.html
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.html
@@ -148,6 +148,44 @@
           </ion-row>
         </ion-col>
       </ion-row>
+      <ion-row>
+        <ion-col class="ion-padding" size="12" size-md="7">
+          <ion-row>
+            <ion-title class="ion-text-start ion-no-padding" color="medium">
+              Archivos entregados (Acumulación contada trimestralmente)
+            </ion-title>
+            <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
+            <apx-chart
+              class="chart"
+              [series]="filesAccChart.series"
+              [chart]="filesAccChart.chart"
+              [xaxis]="filesAccChart.xaxis"
+              [dataLabels]="filesAccChart.dataLabels"
+              [colors]="filesAccChart.colors"
+              [legend]="filesAccChart.legend"
+              [yaxis]="filesAccChart.yaxis"
+            ></apx-chart>
+          </ion-row>
+        </ion-col>
+        <ion-col class="ion-padding" size="12" size-md="5">
+          <ion-row>
+            <ion-title class="ion-text-start ion-no-padding" color="medium">
+              Datos entregados (Acumulación contada trimestralmente)
+            </ion-title>
+            <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
+            <apx-chart
+              class="chart"
+              [series]="filesSizeAccChart.series"
+              [chart]="filesSizeAccChart.chart"
+              [xaxis]="filesSizeAccChart.xaxis"
+              [dataLabels]="filesSizeAccChart.dataLabels"
+              [colors]="filesSizeAccChart.colors"
+              [legend]="filesSizeAccChart.legend"
+              [yaxis]="filesSizeAccChart.yaxis"
+            ></apx-chart>
+          </ion-row>
+        </ion-col>
+      </ion-row>
     </ion-grid>
   </div>
 </ion-content>

--- a/src/app/estadisticas/tablero-general/tablero-general.component.html
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.html
@@ -32,7 +32,7 @@
   <div ion-fixed>
     <ion-grid class="ion-padding">
       <ion-row>
-        <ion-col class="ion-padding" size="12" size-md="7">
+        <ion-col class="ion-padding" size="12" size-md="9">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium"> Visitas Registradas </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
@@ -69,7 +69,7 @@
           </ion-row>
         </ion-col>
 
-        <ion-col class="ion-padding" size="12" size-md="5">
+        <ion-col class="ion-padding" size="12" size-md="3">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium"> Dispositivos adquiridos </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
@@ -115,7 +115,7 @@
       </ion-row>
 
       <ion-row>
-        <ion-col class="ion-padding" size="12" size-md="7">
+        <ion-col class="ion-padding" size="12" size-md="6">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium"> Archivos entregados </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
@@ -131,7 +131,7 @@
             ></apx-chart>
           </ion-row>
         </ion-col>
-        <ion-col class="ion-padding" size="12" size-md="5">
+        <ion-col class="ion-padding" size="12" size-md="6">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium"> Datos entregados </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
@@ -149,10 +149,10 @@
         </ion-col>
       </ion-row>
       <ion-row>
-        <ion-col class="ion-padding" size="12" size-md="7">
+        <ion-col class="ion-padding" size="12" size-md="4">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium">
-              Archivos entregados (Acumulación contada trimestralmente)
+              Imágenes y videos entregados (Acumulación trimestral)
             </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart
@@ -167,10 +167,29 @@
             ></apx-chart>
           </ion-row>
         </ion-col>
-        <ion-col class="ion-padding" size="12" size-md="5">
+        <ion-col class="ion-padding" size="12" size-md="4">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium">
-              Datos entregados (Acumulación contada trimestralmente)
+              Archivos de audio entregados (Acumulación trimestral)
+            </ion-title>
+            <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
+            <apx-chart
+              class="chart"
+              [series]="filesAudioChart.series"
+              [chart]="filesAudioChart.chart"
+              [xaxis]="filesAudioChart.xaxis"
+              [dataLabels]="filesAccChart.dataLabels"
+              [colors]="filesAudioChart.colors"
+              [legend]="filesAudioChart.legend"
+              [yaxis]="filesAudioChart.yaxis"
+            ></apx-chart>
+          </ion-row>
+        </ion-col>
+
+        <ion-col class="ion-padding" size="12" size-md="4">
+          <ion-row>
+            <ion-title class="ion-text-start ion-no-padding" color="medium">
+              Datos entregados (Acumulación trimestral)
             </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart

--- a/src/app/estadisticas/tablero-general/tablero-general.component.ts
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.ts
@@ -357,6 +357,44 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
   };
 
+  filesAudioChart: ApexOptions = {
+    series: [
+      {
+        name: 'Audio',
+        data: [],
+      },
+    ],
+    chart: {
+      type: 'area',
+      height: 350,
+      stacked: false,
+    },
+    colors: this.colors,
+    dataLabels: {
+      enabled: false,
+    },
+    legend: {
+      position: 'top',
+      horizontalAlign: 'left',
+    },
+    xaxis: {
+      title: {
+        text: 'Trimestre',
+      },
+      categories: [],
+    },
+    yaxis: {
+      title: {
+        text: 'Archivos de audio entregados (Acumulados)',
+      },
+      min: 0,
+      forceNiceScale: true,
+      labels: {
+        formatter: this.shortNumber,
+      },
+    },
+  };
+
   filesAccChart: ApexOptions = {
     series: [
       {
@@ -406,7 +444,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   filesSizeAccChart: ApexOptions = {
     series: [
       {
-        name: 'GB',
+        name: 'MB',
         data: [],
       },
     ],
@@ -431,7 +469,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
     yaxis: {
       title: {
-        text: 'Datos entregados (GB Acumulados)',
+        text: 'Datos entregados (MB Acumulados)',
       },
       min: 0,
       forceNiceScale: true,
@@ -455,7 +493,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
       sufix = 'M';
     }
 
-    if (value >= 100000) {
+    if (value >= 1000) {
       value = value / 1000;
       sufix = 'K';
     }
@@ -557,11 +595,17 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
         });
       });
 
-      this.filesAccChart.series = [
+      this.filesAudioChart.series = [
         {
           name: 'Audio',
           data: audio,
         },
+      ];
+      this.filesAudioChart.xaxis = {
+        categories,
+      };
+
+      this.filesAccChart.series = [
         {
           name: 'Video',
           data: video,

--- a/src/app/estadisticas/tablero-general/tablero-general.component.ts
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.ts
@@ -58,6 +58,19 @@ export type ChartOptions = {
 
 const updateTimeout = 300;
 
+const inArray = (array) => (input) => _.includes(array, input);
+
+const monthToFourMountPeriod = (month) => {
+  const f = _.cond([
+    [inArray([0, 1, 2]), _.constant(1)],
+    [inArray([3, 4, 5]), _.constant(2)],
+    [inArray([6, 7, 8]), _.constant(3)],
+    [inArray([9, 10, 11]), _.constant(4)],
+    [_.stubTrue, _.constant(-1)],
+  ]);
+  return f(month);
+};
+
 @Component({
   selector: 'app-tablero-general',
   templateUrl: './tablero-general.component.html',
@@ -344,6 +357,90 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
   };
 
+  filesAccChart: ApexOptions = {
+    series: [
+      {
+        name: 'Audio',
+        data: [],
+      },
+      {
+        name: 'Video',
+        data: [],
+      },
+      {
+        name: 'Imágenes',
+        data: [],
+      },
+    ],
+    chart: {
+      type: 'area',
+      height: 350,
+      stacked: false,
+    },
+    colors: this.colors,
+    dataLabels: {
+      enabled: false,
+    },
+    legend: {
+      position: 'top',
+      horizontalAlign: 'left',
+    },
+    xaxis: {
+      title: {
+        text: 'Trimestre',
+      },
+      categories: [],
+    },
+    yaxis: {
+      title: {
+        text: 'Archivos entregados (Acumulados)',
+      },
+      min: 0,
+      forceNiceScale: true,
+      labels: {
+        formatter: this.shortNumber,
+      },
+    },
+  };
+
+  filesSizeAccChart: ApexOptions = {
+    series: [
+      {
+        name: 'GB',
+        data: [],
+      },
+    ],
+    chart: {
+      type: 'area',
+      height: 350,
+      stacked: false,
+    },
+    colors: this.colors,
+    dataLabels: {
+      enabled: false,
+    },
+    legend: {
+      position: 'top',
+      horizontalAlign: 'left',
+    },
+    xaxis: {
+      title: {
+        text: 'Trimestre',
+      },
+      categories: [],
+    },
+    yaxis: {
+      title: {
+        text: 'Datos entregados (GB Acumulados)',
+      },
+      min: 0,
+      forceNiceScale: true,
+      labels: {
+        formatter: this.shortNumber,
+      },
+    },
+  };
+
   constructor(private alertController: AlertController, private apollo: Apollo, private route: ActivatedRoute) {
     this.cumuloId = this.route.snapshot.paramMap.get('id') || null;
   }
@@ -392,6 +489,105 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
       this.cumulusByEcosystem = _.groupBy(cumulus, (c) => c.ecosystem_id);
     } catch (error) {
       console.log(error);
+    }
+  }
+
+  async partition_files() {
+    let files: any = null;
+    try {
+      const { data }: any = await this.apollo
+        .query({
+          query: getAllFiles,
+          variables: {
+            pagination: {
+              limit: 1000,
+              offset: 0,
+            },
+          },
+        })
+        .toPromise();
+
+      let files: any = _.sortBy(data.file_counts, ['delivery_date']);
+
+      files = _.groupBy(files, (f) => new Date(f.delivery_date).getFullYear());
+      Object.keys(files).forEach((key) => {
+        files[key] = _.groupBy(files[key], (f) => monthToFourMountPeriod(new Date(f.delivery_date).getMonth()));
+        Object.keys(files[key]).forEach((key2) => {
+          files[key][key2] = _.reduce(
+            files[key][key2],
+            (result, obj) => {
+              return {
+                audio_files: result.audio_files + obj.audio_files,
+                image_files: result.image_files + obj.image_files,
+                video_files: result.video_files + obj.video_files,
+                size: result.size + obj.size / 1024,
+              };
+            },
+            {
+              audio_files: 0,
+              image_files: 0,
+              video_files: 0,
+              size: 0,
+            }
+          );
+        });
+      });
+
+      const categories = [];
+      const audio = [];
+      const video = [];
+      const images = [];
+      const size = [];
+      let audiot = 0;
+      let videot = 0;
+      let imagest = 0;
+      let sizet = 0;
+
+      Object.keys(files).forEach((year) => {
+        Object.keys(files[year]).forEach((fourMonthPeriod) => {
+          categories.push(`${year}-0${fourMonthPeriod}`);
+          audiot += files[year][fourMonthPeriod].audio_files;
+          videot += files[year][fourMonthPeriod].video_files;
+          imagest += files[year][fourMonthPeriod].image_files;
+          sizet += files[year][fourMonthPeriod].size;
+          audio.push(audiot);
+          video.push(videot);
+          images.push(imagest);
+          size.push(sizet.toFixed(2));
+        });
+      });
+
+      this.filesAccChart.series = [
+        {
+          name: 'Audio',
+          data: audio,
+        },
+        {
+          name: 'Video',
+          data: video,
+        },
+        {
+          name: 'Imágenes',
+          data: images,
+        },
+      ];
+
+      this.filesAccChart.xaxis = {
+        categories,
+      };
+
+      this.filesSizeAccChart.series = [
+        {
+          name: 'MB',
+          data: size,
+        },
+      ];
+
+      this.filesSizeAccChart.xaxis = {
+        categories,
+      };
+    } catch (error) {
+      console.error('Error al obtener los archivos', error);
     }
   }
 
@@ -753,6 +949,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     await this.getFormularios();
     await this.getDevices();
     await this.getFiles();
+    await this.partition_files();
     // this.getTransects();
   }
 }


### PR DESCRIPTION
In this pull request, the dashboard now displays graphs showing the cumulative number and size of delivered files over three-month periods.

![Captura desde 2023-11-23 09-08-58](https://github.com/CONABIO-MONITOREO/sipecam_points/assets/5816646/ee1e2fef-2dba-4b36-a06c-a218f386d670)
