### PR TITLE
Adjustments to loading ellipsis in about-us page

### DIFF
--- a/src/app/about/components/intro/intro.component.html
+++ b/src/app/about/components/intro/intro.component.html
@@ -1,4 +1,5 @@
 <div>
+  <!-- intro logos -->
   <div class="box-intro bg-color-transition" [style.background-color]="bgColor">
     <div @logoOut *ngIf="introState <= 1" class="bg-logo-1 box-bg"></div>
     <div @logoOut *ngIf="introState === 2 || introState >= 102 || hoverLineId === 2" class="bg-logo-2 box-bg"></div>
@@ -9,17 +10,19 @@
     <div @logoOut *ngIf="introState === 7 || introState >= 107 || hoverLineId === 7" class="bg-logo-7 box-bg"></div>
     <div @logoOut *ngIf="introState === 8 || introState >= 108 || hoverLineId === 8" class="bg-logo-8 box-bg"></div>
     <div *ngIf="introState >= 9 && hoverLineId === 0" class="bg-logo-100 box-bg"></div>
-  </div>
 
-  <div *ngIf="imagesLoading" class="flex-box-a">
-    <div class="lds-ellipsis">
-      <div></div>
-      <div></div>
-      <div></div>
-      <div></div>
+    <!-- loading ellipsis -->
+    <div *ngIf="imagesLoading" class="flex-box-a lds-ellipsis-container">
+      <div class="lds-ellipsis">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
     </div>
   </div>
 
+  <!-- lines -->
   <div *ngIf="!imagesError" class="flex-box-a lines-container">
     <div
       @lineIn

--- a/src/app/about/components/intro/intro.component.scss
+++ b/src/app/about/components/intro/intro.component.scss
@@ -188,6 +188,12 @@
 // ------- -------
 // loading ellipsis
 // ------- -------
+.lds-ellipsis-container {
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+}
+
 .lds-ellipsis {
   display: inline-block;
   position: relative;

--- a/src/app/about/components/intro/intro.component.ts
+++ b/src/app/about/components/intro/intro.component.ts
@@ -84,7 +84,7 @@ export class IntroComponent implements OnInit {
         this.bgColor = '#000';
         this.introStarted.emit();
         resolve(true);
-      }, this.timeout1s);
+      }, 0);
     });
 
     await new Promise((resolve) => {


### PR DESCRIPTION
# Description
- Adjusted ellipsis container position to `absolute`, to prevent jumps in the content after removing the ellipsis from the DOM.