### PR TITLE
Update charts

### DIFF
--- a/src/app/estadisticas/tablero-general/tablero-general.component.html
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.html
@@ -71,7 +71,7 @@
 
         <ion-col class="ion-padding" size="12" size-md="3">
           <ion-row>
-            <ion-title class="ion-text-start ion-no-padding" color="medium"> Dispositivos adquiridos </ion-title>
+            <ion-title class="ion-text-start ion-margin-top" color="medium"> Dispositivos adquiridos </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart
               class="chart"
@@ -85,7 +85,7 @@
           </ion-row>
 
           <ion-row>
-            <ion-title class="ion-text-start ion-no-padding" color="medium"> Dispositivos en campo </ion-title>
+            <ion-title class="ion-text-start ion-margin-top" color="medium"> Dispositivos en campo </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart
               class="chart"
@@ -99,7 +99,7 @@
           </ion-row>
 
           <ion-row>
-            <ion-title class="ion-text-start ion-no-padding" color="medium"> Estado de los dispositivos </ion-title>
+            <ion-title class="ion-text-start ion-margin-top" color="medium"> Estado de los dispositivos </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart
               class="chart"
@@ -133,7 +133,7 @@
         </ion-col>
         <ion-col class="ion-padding" size="12" size-md="6">
           <ion-row>
-            <ion-title class="ion-text-start ion-no-padding" color="medium"> Datos entregados </ion-title>
+            <ion-title class="ion-text-start ion-no-padding" color="medium"> Datos entregados (Terabytes) </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart
               class="chart"
@@ -152,7 +152,7 @@
         <ion-col class="ion-padding" size="12" size-md="4">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium">
-              Imágenes y videos entregados (Acumulación trimestral)
+              Archivos de imágenes y videos entregados (Acumulación trimestral)
             </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart
@@ -189,7 +189,7 @@
         <ion-col class="ion-padding" size="12" size-md="4">
           <ion-row>
             <ion-title class="ion-text-start ion-no-padding" color="medium">
-              Datos entregados (Acumulación trimestral)
+              Datos entregados (Acumulación trimestral - Terabytes)
             </ion-title>
             <ion-item-divider class="ion-margin-top" color="light"></ion-item-divider>
             <apx-chart

--- a/src/app/estadisticas/tablero-general/tablero-general.component.ts
+++ b/src/app/estadisticas/tablero-general/tablero-general.component.ts
@@ -109,7 +109,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     ],
     chart: {
       type: 'bar',
-      height: 350,
+      height: 400,
       toolbar: { show: false },
     },
     plotOptions: {
@@ -161,7 +161,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
       },
     ],
     chart: {
-      height: 350,
+      height: 400,
       type: 'bar',
       toolbar: { show: false },
     },
@@ -210,12 +210,12 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   devicesStatusChart: ApexOptions = {
     series: [],
     chart: {
-      height: 250,
+      height: 300,
       type: 'donut',
     },
     labels: [],
     legend: {
-      position: 'left',
+      position: 'bottom',
     },
     plotOptions: {
       pie: {
@@ -234,12 +234,12 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   devicesTypeChart: ApexOptions = {
     series: [],
     chart: {
-      height: 250,
+      height: 300,
       type: 'donut',
     },
     labels: [],
     legend: {
-      position: 'left',
+      position: 'bottom',
     },
     plotOptions: {
       pie: {
@@ -258,12 +258,12 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   activeDevicesChart: ApexOptions = {
     series: [],
     chart: {
-      height: 250,
+      height: 300,
       type: 'donut',
     },
     labels: [],
     legend: {
-      position: 'left',
+      position: 'bottom',
     },
     plotOptions: {
       pie: {
@@ -312,7 +312,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
     yaxis: {
       title: {
-        text: 'Archivos entregados',
+        text: '',
       },
       min: 0,
       forceNiceScale: true,
@@ -325,7 +325,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   filesSizeChart: ApexOptions = {
     series: [
       {
-        name: 'GB',
+        name: 'TB',
         data: [],
       },
     ],
@@ -347,7 +347,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
     yaxis: {
       title: {
-        text: 'Datos entregados (GB)',
+        text: '',
       },
       min: 0,
       forceNiceScale: true,
@@ -385,7 +385,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
     yaxis: {
       title: {
-        text: 'Archivos de audio entregados (Acumulados)',
+        text: '',
       },
       min: 0,
       forceNiceScale: true,
@@ -431,7 +431,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
     yaxis: {
       title: {
-        text: 'Archivos entregados (Acumulados)',
+        text: '',
       },
       min: 0,
       forceNiceScale: true,
@@ -444,7 +444,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
   filesSizeAccChart: ApexOptions = {
     series: [
       {
-        name: 'MB',
+        name: 'TB',
         data: [],
       },
     ],
@@ -469,7 +469,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
     },
     yaxis: {
       title: {
-        text: 'Datos entregados (MB Acumulados)',
+        text: '',
       },
       min: 0,
       forceNiceScale: true,
@@ -590,7 +590,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
           audio.push(audiot);
           video.push(videot);
           images.push(imagest);
-          size.push(sizet.toFixed(2));
+          size.push((sizet / 1000000).toFixed(2));
         });
       });
 
@@ -621,7 +621,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
 
       this.filesSizeAccChart.series = [
         {
-          name: 'MB',
+          name: 'TB',
           data: size,
         },
       ];
@@ -732,7 +732,7 @@ export class TableroGeneralComponent implements OnInit, AfterViewInit {
 
     this.filesSizeChart.series = [
       {
-        name: 'MB',
+        name: 'TB',
         data: size,
       },
     ];


### PR DESCRIPTION
In this pull request, the following changes were made:

- Labels and charts were updated to show data accumulation in three-month periods instead of delivery dates. Also, it was removed labels with duplicated text.
- Labels of pie charts are now placed at the bottom. 

![image](https://github.com/CONABIO-MONITOREO/sipecam_points/assets/5816646/cec0b436-c4df-431b-911f-6ffac2bced75)

![image](https://github.com/CONABIO-MONITOREO/sipecam_points/assets/5816646/0fe96ce0-7fb7-4981-a2b3-b33b3f2e518c)

